### PR TITLE
Fix certain layouts leaking empty slots into next data

### DIFF
--- a/worlds/sc2/mission_order/structs.py
+++ b/worlds/sc2/mission_order/structs.py
@@ -217,8 +217,7 @@ class SC2MissionOrder(MissionOrderNode):
             # Check for accessible missions
             cur_missions: Set[SC2MOGenMission] = {
                 mission for mission in next_missions
-                if not mission.option_empty
-                and mission.is_unlocked(beaten_missions)
+                if mission.is_unlocked(beaten_missions)
             }
             if len(cur_missions) == 0:
                 raise Exception(f"Mission order ran out of accessible missions during iteration {iterations}")
@@ -231,9 +230,7 @@ class SC2MissionOrder(MissionOrderNode):
                 # If the beaten missions at depth X unlock a mission, said mission can be beaten at depth X+1 
                 mission.min_depth = mission.entry_rule.get_depth(beaten_missions) + 1
                 new_next = [
-                    next_mission for next_mission in mission.next
-                    if not next_mission.option_empty
-                    and not (
+                    next_mission for next_mission in mission.next if not (
                         next_mission in cur_missions
                         or next_mission in beaten_missions
                         or next_mission in new_beaten_missions
@@ -710,23 +707,15 @@ class SC2MOGenLayout(MissionOrderNode):
                 mission.next = [self.missions[idx] for idx in mission.option_next]
         
         # Set up missions' prev data
-        seen_missions: Set[SC2MOGenMission] = set()
-        cur_missions: List[SC2MOGenMission] = [mission for mission in self.entrances]
-        while len(cur_missions) > 0:
-            mission = cur_missions.pop()
-            seen_missions.add(mission)
+        for mission in self.missions:
             for next_mission in mission.next:
                 next_mission.prev.append(mission)
-                if next_mission not in seen_missions and \
-                   next_mission not in cur_missions:
-                    cur_missions.append(next_mission)
         
         # Remove empty missions from access data
         for mission in self.missions:
             if mission.option_empty:
                 for next_mission in mission.next:
-                    if mission in next_mission.prev:
-                        next_mission.prev.remove(mission)
+                    next_mission.prev.remove(mission)
                 mission.next.clear()
                 for prev_mission in mission.prev:
                     prev_mission.next.remove(mission)


### PR DESCRIPTION
## What is this fixing or adding?
This reverts the empty slot checks in the depth fill and instead changes the initial `next` setup to be more thorough.

`next` and `prev` are supposed to *never* contain empty slots for ease of iteration. It seems currently this is only relevant for the depth fill, but this wasn't always the case during development, so I wouldn't exclude the possibility that it will be used elsewhere in the future.

I'm not sure what the concrete issue with the YAML was, but I figured out that it had to do with dynamically changing entrance slots (due to empty settings on and around entrances) causing some missions to be overlooked in the initial `prev` fill and thus empty slots not always finding every mission that points at them, so the fix is to just go over all missions instead of starting from a potentially false list of entrances.

## How was this tested?
Generated successfully with the YAML from https://github.com/Ziktofel/Archipelago/pull/354