### PR TITLE
SC2: Update tests for new defaults

### DIFF
--- a/worlds/sc2/test/test_base.py
+++ b/worlds/sc2/test/test_base.py
@@ -8,7 +8,7 @@ from worlds import AutoWorld
 from test.general import gen_steps, call_all
 
 from test.bases import WorldTestBase
-from .. import SC2World
+from .. import SC2World, SC2Campaign
 from .. import client
 from .. import options
 
@@ -27,6 +27,15 @@ class Sc2SetupTestBase(unittest.TestCase):
     """
     ALL_CAMPAIGNS = {
         'enabled_campaigns': options.EnabledCampaigns.valid_keys,
+    }
+    TERRAN_CAMPAIGNS = {
+        'enabled_campaigns': {SC2Campaign.WOL.campaign_name, SC2Campaign.NCO.campaign_name,}
+    }
+    ZERG_CAMPAIGNS = {
+        'enabled_campaigns': {SC2Campaign.HOTS.campaign_name,}
+    }
+    PROTOSS_CAMPAIGNS = {
+        'enabled_campaigns': {SC2Campaign.PROPHECY.campaign_name, SC2Campaign.PROLOGUE.campaign_name, SC2Campaign.LOTV.campaign_name,}
     }
     seed: Optional[int] = None
     game = SC2World.game

--- a/worlds/sc2/test/test_generation.py
+++ b/worlds/sc2/test/test_generation.py
@@ -15,6 +15,7 @@ from ..options import EnabledCampaigns, NovaGhostOfAChanceVariant, MissionOrder,
 class TestItemFiltering(Sc2SetupTestBase):
     def test_explicit_locks_excludes_interact_and_set_flags(self):
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'locked_items': {
                 item_names.MARINE: 0,
                 item_names.MARAUDER: 0,
@@ -115,6 +116,8 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_excluding_mission_groups_excludes_all_missions_in_group(self):
         world_options = {
+            **self.ZERG_CAMPAIGNS,
+            'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
             'excluded_missions': [
                 mission_groups.MissionGroupNames.HOTS_ZERUS_MISSIONS,
             ],
@@ -158,6 +161,7 @@ class TestItemFiltering(Sc2SetupTestBase):
     def test_excluding_all_terran_missions_excludes_all_terran_items(self) -> None:
         world_options = {
             **self.ALL_CAMPAIGNS,
+            'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'excluded_missions': [
@@ -173,6 +177,8 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_excluding_all_terran_build_missions_excludes_all_terran_units(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
+            'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'excluded_missions': [
@@ -191,6 +197,8 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_excluding_all_zerg_and_kerrigan_missions_excludes_all_zerg_items(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
+            'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'excluded_missions': [
@@ -206,6 +214,8 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_excluding_all_zerg_build_missions_excludes_zerg_units(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
+            'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'excluded_missions': [
@@ -225,6 +235,8 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_excluding_all_protoss_missions_excludes_all_protoss_items(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
+            'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'accessibility': 'locations',
@@ -242,6 +254,8 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_excluding_all_protoss_build_missions_excludes_protoss_units(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
+            'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'accessibility': 'locations',
@@ -287,6 +301,7 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_vanilla_items_only_includes_only_nova_equipment_and_vanilla_and_filler_items(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             # Avoid options that lock non-vanilla items for logic
@@ -758,7 +773,6 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_kerrigan_levels_per_mission_triggering_pre_fill(self):
         world_options = {
-            # Vanilla WoL with all missions
             **self.ALL_CAMPAIGNS,
             'mission_order': options.MissionOrder.option_custom,
             'custom_mission_order': {
@@ -800,7 +814,6 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_kerrigan_levels_per_mission_and_generic_upgrades_both_triggering_pre_fill(self):
         world_options = {
-            # Vanilla WoL with all missions
             **self.ALL_CAMPAIGNS,
             'mission_order': options.MissionOrder.option_custom,
             'custom_mission_order': {
@@ -926,6 +939,7 @@ class TestItemFiltering(Sc2SetupTestBase):
             },
             'max_number_of_upgrades': 2,
             'mission_order': options.MissionOrder.option_grid,
+            **self.ALL_CAMPAIGNS,
             'selected_races': {
                 SC2Race.TERRAN.get_title(),
             },
@@ -962,6 +976,7 @@ class TestItemFiltering(Sc2SetupTestBase):
             },
             'max_number_of_upgrades': 2,
             'mission_order': options.MissionOrder.option_grid,
+            **self.ALL_CAMPAIGNS,
             'selected_races': {
                 SC2Race.TERRAN.get_title(),
                 SC2Race.ZERG.get_title(),
@@ -992,6 +1007,7 @@ class TestItemFiltering(Sc2SetupTestBase):
             },
             'max_upgrade_level': MAX_LEVEL,
             'mission_order': options.MissionOrder.option_grid,
+            **self.ALL_CAMPAIGNS,
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
             'generic_upgrade_items': options.GenericUpgradeItems.option_bundle_weapon_and_armor
         }
@@ -1018,12 +1034,13 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_ghost_of_a_chance_generates_without_nco(self) -> None:
         world_options = {
+            **self.TERRAN_CAMPAIGNS,
             'mission_order': MissionOrder.option_custom,
             'nova_ghost_of_a_chance_variant': NovaGhostOfAChanceVariant.option_auto,
             'custom_mission_order': {
                 'test': {
                     'type': 'column',
-                    'size': 1, # Give the generator some space to place the key
+                    'size': 1,
                     'mission_pool': [
                         SC2Mission.GHOST_OF_A_CHANCE.mission_name
                     ]
@@ -1039,12 +1056,13 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_ghost_of_a_chance_generates_using_nco_nova(self) -> None:
         world_options = {
+            **self.TERRAN_CAMPAIGNS,
             'mission_order': MissionOrder.option_custom,
             'nova_ghost_of_a_chance_variant': NovaGhostOfAChanceVariant.option_nco,
             'custom_mission_order': {
                 'test': {
                     'type': 'column',
-                    'size': 2, # Give the generator some space to place the key
+                    'size': 2,
                     'mission_pool': [
                         SC2Mission.LIBERATION_DAY.mission_name, # Starter mission
                         SC2Mission.GHOST_OF_A_CHANCE.mission_name,
@@ -1060,13 +1078,13 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_ghost_of_a_chance_generates_with_nco(self) -> None:
         world_options = {
-            **self.ALL_CAMPAIGNS,
+            **self.TERRAN_CAMPAIGNS,
             'mission_order': MissionOrder.option_custom,
             'nova_ghost_of_a_chance_variant': NovaGhostOfAChanceVariant.option_auto,
             'custom_mission_order': {
                 'test': {
                     'type': 'column',
-                    'size': 3, # Give the generator some space to place the key
+                    'size': 3,
                     'mission_pool': [
                         SC2Mission.LIBERATION_DAY.mission_name, # Starter mission
                         SC2Mission.GHOST_OF_A_CHANCE.mission_name,
@@ -1085,6 +1103,7 @@ class TestItemFiltering(Sc2SetupTestBase):
         world_options = {
             **self.ALL_CAMPAIGNS,
             'mission_order': MissionOrder.option_grid,
+            'maximum_campaign_size': MaximumCampaignSize.range_end,
             'exclude_overpowered_items': ExcludeOverpoweredItems.option_true,
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
             'selected_races': [SC2Race.TERRAN.get_title()],
@@ -1102,6 +1121,7 @@ class TestItemFiltering(Sc2SetupTestBase):
         world_options = {
             **self.ALL_CAMPAIGNS,
             'mission_order': MissionOrder.option_grid,
+            'maximum_campaign_size': MaximumCampaignSize.range_end,
             'exclude_overpowered_items': ExcludeOverpoweredItems.option_false,
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
             'selected_races': [SC2Race.TERRAN.get_title()],
@@ -1117,7 +1137,9 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_exclude_overpowered_items_vanilla_only(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': MissionOrder.option_grid,
+            'maximum_campaign_size': MaximumCampaignSize.range_end,
             'exclude_overpowered_items': ExcludeOverpoweredItems.option_true,
             'vanilla_items_only': VanillaItemsOnly.option_true,
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
@@ -1134,7 +1156,9 @@ class TestItemFiltering(Sc2SetupTestBase):
     def test_exclude_locked_overpowered_items(self) -> None:
         locked_item = item_names.BATTLECRUISER_ATX_LASER_BATTERY
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': MissionOrder.option_grid,
+            'maximum_campaign_size': MaximumCampaignSize.range_end,
             'exclude_overpowered_items': ExcludeOverpoweredItems.option_true,
             'locked_items': [locked_item],
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
@@ -1152,7 +1176,9 @@ class TestItemFiltering(Sc2SetupTestBase):
         Checks if all unreleased items are marked properly not to generate
         """
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': MissionOrder.option_grid,
+            'maximum_campaign_size': MaximumCampaignSize.range_end,
             'exclude_overpowered_items': ExcludeOverpoweredItems.option_false,
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
         }
@@ -1170,7 +1196,9 @@ class TestItemFiltering(Sc2SetupTestBase):
         Locking overrides this behavior - if they're locked, they must appear
         """
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': MissionOrder.option_grid,
+            'maximum_campaign_size': MaximumCampaignSize.range_end,
             'exclude_overpowered_items': ExcludeOverpoweredItems.option_false,
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
             'locked_items': {item_name: 0 for item_name in unreleased_items},
@@ -1185,10 +1213,12 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_merc_excluded_excludes_merc_upgrades(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': MissionOrder.option_grid,
             'maximum_campaign_size': MaximumCampaignSize.range_end,
             'excluded_items': [item_name for item_name in item_groups.terran_mercenaries],
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
+            'selected_races': [SC2Race.TERRAN.get_title()],
         }
 
         self.generate_world(world_options)
@@ -1204,6 +1234,7 @@ class TestItemFiltering(Sc2SetupTestBase):
             'exclude_overpowered_items': ExcludeOverpoweredItems.option_true,
             'unexcluded_items': [item_names.SOA_TIME_STOP],
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
+            'selected_races': [SC2Race.PROTOSS.get_title()],
         }
 
         self.generate_world(world_options)
@@ -1222,11 +1253,13 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_exclude_overpowered_items_and_not_allow_unit_nerfs(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': MissionOrder.option_grid,
             'maximum_campaign_size': MaximumCampaignSize.range_end,
             'exclude_overpowered_items': ExcludeOverpoweredItems.option_true,
             'war_council_nerfs': options.WarCouncilNerfs.option_false,
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
+            'selected_races': [SC2Race.PROTOSS.get_title()],
         }
 
         self.generate_world(world_options)

--- a/worlds/sc2/test/test_generation.py
+++ b/worlds/sc2/test/test_generation.py
@@ -1234,7 +1234,6 @@ class TestItemFiltering(Sc2SetupTestBase):
             'exclude_overpowered_items': ExcludeOverpoweredItems.option_true,
             'unexcluded_items': [item_names.SOA_TIME_STOP],
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
-            'selected_races': [SC2Race.PROTOSS.get_title()],
         }
 
         self.generate_world(world_options)

--- a/worlds/sc2/test/test_item_filtering.py
+++ b/worlds/sc2/test/test_item_filtering.py
@@ -15,6 +15,7 @@ class ItemFilterTests(Sc2SetupTestBase):
             },
             'required_tactics': 'standard',
             'min_number_of_upgrades': 1,
+            **self.TERRAN_CAMPAIGNS,
             'selected_races': {
                 SC2Race.TERRAN.get_title()
             },
@@ -54,6 +55,7 @@ class ItemFilterTests(Sc2SetupTestBase):
             },
             'min_number_of_upgrades': 2,
             'required_tactics': 'standard',
+            **self.ALL_CAMPAIGNS,
             'selected_races': {
                 SC2Race.PROTOSS.get_title()
             },
@@ -68,7 +70,6 @@ class ItemFilterTests(Sc2SetupTestBase):
 
     def test_excluding_all_items_in_multiparent_excludes_child_items(self) -> None:
         world_options = {
-            **self.ALL_CAMPAIGNS,
             'excluded_items': {
                 item_names.ZEALOT: 1,
                 item_names.SENTINEL: 1,
@@ -76,6 +77,7 @@ class ItemFilterTests(Sc2SetupTestBase):
             },
             'min_number_of_upgrades': 2,
             'required_tactics': 'standard',
+            **self.PROTOSS_CAMPAIGNS,
             'selected_races': {
                 SC2Race.PROTOSS.get_title()
             },

--- a/worlds/sc2/test/test_usecases.py
+++ b/worlds/sc2/test/test_usecases.py
@@ -341,6 +341,7 @@ class TestSupportedUseCases(Sc2SetupTestBase):
     def test_kerrigan_max_active_abilities(self):
         target_number: int = 8
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'selected_races': {
@@ -359,6 +360,7 @@ class TestSupportedUseCases(Sc2SetupTestBase):
     def test_kerrigan_max_passive_abilities(self):
         target_number: int = 3
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'selected_races': {
@@ -377,6 +379,7 @@ class TestSupportedUseCases(Sc2SetupTestBase):
     def test_spear_of_adun_max_active_abilities(self):
         target_number: int = 8
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'selected_races': {
@@ -396,6 +399,7 @@ class TestSupportedUseCases(Sc2SetupTestBase):
     def test_spear_of_adun_max_autocasts(self):
         target_number: int = 2
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'selected_races': {
@@ -415,6 +419,7 @@ class TestSupportedUseCases(Sc2SetupTestBase):
     def test_nova_max_weapons(self):
         target_number: int = 3
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'selected_races': {
@@ -434,6 +439,7 @@ class TestSupportedUseCases(Sc2SetupTestBase):
     def test_nova_max_gadgets(self):
         target_number: int = 3
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'selected_races': {
@@ -451,6 +457,7 @@ class TestSupportedUseCases(Sc2SetupTestBase):
     
     def test_mercs_only(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'selected_races': [
                 SC2Race.TERRAN.get_title(),
                 SC2Race.ZERG.get_title(),


### PR DESCRIPTION
## What is this fixing or adding?
This is the result of me double-checking all the tests that interact with world generation and updating them with the new defaults to match what I believe to be the intended test cases. This also includes updating some older tests to respect race-swaps, which means they'll run slower than they used to, and in a handful of cases making tests with similar goals more similar in their world setups, which isn't strictly necessary but just felt correct to do. Lastly there were also a few copy-pasted comments that made no sense in their new places, so I deleted those.

My changes focused on `enabled_campaigns` because a lot of tests already have `mission_order` set and I figure if the test doesn't obviously need vanilla, then golden path will be easier to generate anyway.

Here is my reasoning for individual changes:
```
test_usecases.py
  test_kerrigan_max_active_abilities
  test_kerrigan_max_passive_abilities
  test_spear_of_adun_max_active_abilities
  test_spear_of_adun_max_autocasts
  test_nova_max_weapons
  test_nova_max_gadgets
test_generation.py
  test_weapon_armor_upgrade_items_capped_by_max_upgrade_level
```
These are all pretty much the same: They generate a huge amount of locations of a given race (or all races for the W/A test) to ensure there are more locations than items, to check that the tested item type isn't placed more often than desired despite the available space. There is an argument to be made that they generate considerably more locations than necessary, but giving them as many locations as possible is a form of future-proofing, so I opted to give them all campaigns.

```
test_usecases.py
  test_mercs_only
```
This test requires both Terran and Zerg missions so it can generate mercs of both races, so I gave it all campaigns.

```
test_item_filtering.py
  test_excluding_all_barracks_units_excludes_infantry_upgrades
  test_excluding_all_items_in_multiparent_excludes_child_items
```
These two specifically filter for Terran & Protoss missions respectively. I'm not sure for either one what the expectation for location count is, so I at least gave them the campaigns of their respective races, which loses them 1 Epilogue mission compared to the old defaults. For the second test I also moved your existing fix next to `selected_races` because I found it easier to parse that way.

```
test_item_filtering.py
  test_excluding_one_item_of_multi_parent_doesnt_filter_children
```
This one uses Protoss missions but has `enable_race_swap: shuffle_all`, so I figured location count might have been a concern when making it. I gave it all campaigns so it has all the missions it expects.

```
test_generation.py
  test_explicit_locks_excludes_interact_and_set_flags
```
This test locks Zealots and excludes Zerglings, so it expects missions of all races.

```
test_generation.py
  test_excluding_mission_groups_excludes_all_missions_in_group
  test_excluding_all_terran_missions_excludes_all_terran_items
  test_excluding_all_terran_build_missions_excludes_all_terran_units
  test_excluding_all_zerg_and_kerrigan_missions_excludes_all_zerg_items
  test_excluding_all_zerg_build_missions_excludes_zerg_units
  test_excluding_all_protoss_missions_excludes_all_protoss_items
  test_excluding_all_protoss_build_missions_excludes_protoss_units
```
Same reasoning for all of these: They want to test things about "all" missions, so they should actually touch all missions. I gave them all campaigns and added `enable_race_swap: shuffle_all`, so these will be the tests running slower now, but this should match their intended test case more completely.

```
test_generation.py
  test_vanilla_items_only_includes_only_nova_equipment_and_vanilla_and_filler_items
```
This test makes assertions about Protoss and NCO items, so I gave it all campaigns so they can possibly generate.

```
test_generation.py
  test_setting_filter_weight_to_zero_excludes_that_item
  test_shields_filler_doesnt_appear_if_no_protoss_missions_appear
```
These tests want to place as much filler as possible to test the filler weights, so I gave them all campaigns.

```
test_generation.py
  test_ghost_of_a_chance_generates_without_nco
  test_ghost_of_a_chance_generates_using_nco_nova
  test_ghost_of_a_chance_generates_with_nco
```
These tests make assertions about interactions between WoL and NCO, so I gave them those two.

```
test_generation.py
  test_exclude_overpowered_items
  test_exclude_overpowered_items_not_excluded
  test_exclude_overpowered_items_vanilla_only
  test_exclude_locked_overpowered_items
  test_unreleased_item_quantity
  test_unreleased_item_quantity_locked
  test_merc_excluded_excludes_merc_upgrades
  test_exclude_overpowered_items_and_not_allow_unit_nerfs
```
These tests all want as many locations as possible to ensure non-filler items are correctly placed or not placed, so I gave them all campaigns, and also bumped up their campaign sizes and applied race filtering where appropriate. I don't really know if bumping up the campaign sizes is necessary, but some of them already do it, so I figure there's a good reason.

## How was this tested?
I waited for the GitHub task that auto-runs unit tests to finish and checked that they succeeded.